### PR TITLE
Remove typo and fix quick installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Phalcon Version Switcher allows you to switch between [Phalcon](https://phalconp
 
 ## Quick Installation
 ```
-curl -L https://raw.githubusercontent.com/yemexx1/phalcon-switcher/master/phalcon-switcher.sh > /usr/local/bin/xdebug-toggle
+curl -L https://raw.githubusercontent.com/yemexx1/phalcon-switcher/master/phalcon-switcher.sh && sudo mv phalcon-switcher.sh /usr/local/bin/phalcon-switcher
 ```
 
 ##Installation with Clone


### PR DESCRIPTION
The quick install command had a typo: `curl -L https://raw.githubusercontent.com/yemexx1/phalcon-switcher/master/phalcon-switcher.sh > /usr/local/bin/xdebug-toggle` notice the xdebug-toggle there, I fixed this.

Also using the quick install command on ubuntu 14.04 didn't work as one needs to `sudo` to move a file into the `/usr/local/bin` directory.
This PR fixes the two issues mentioned above.
